### PR TITLE
[iOS] Added advanced fraud tool (data collector)

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -52,6 +52,14 @@ var Braintree = {
   	});
   }
 
+	getDeviceData(options = {}) {
+		return new Promise(function(resolve, reject) {
+			RCTBraintree.getDeviceData(options, function(err, deviceData) {
+				deviceData != null ? resolve(deviceData) : reject(err);
+			});
+		});
+	}
+
 };
 
 module.exports = Braintree;

--- a/ios/RCTBraintree/RCTBraintree.h
+++ b/ios/RCTBraintree/RCTBraintree.h
@@ -11,11 +11,14 @@
 #import "BraintreePayPal.h"
 #import "BraintreeCard.h"
 #import "BraintreeUI.h"
+#import "BTDataCollector.h"
+#import "PPDataCollector.h"
 
 @interface RCTBraintree : UIViewController <RCTBridgeModule, BTDropInViewControllerDelegate, BTViewControllerPresentingDelegate>
 
 @property (nonatomic, strong) BTAPIClient *braintreeClient;
 @property (nonatomic, strong) UIViewController *reactRoot;
+@property (nonatomic, strong) BTDataCollector *dataCollector;
 
 @property (nonatomic, strong) RCTResponseSenderBlock callback;
 


### PR DESCRIPTION
Added additional method for retrieving device data ([reference](https://developers.braintreepayments.com/guides/advanced-fraud-tools/client-side/ios/v4))

Usage:

```
BTClient.getDeviceData({
  environment: ('development' || 'qa' || 'sandbox'),
  dataCollector: ('card' || 'paypal' || 'both'),
}).then((deviceData) => {
  //Success
  console.log(deviceData)
}).catch((err) => {
  //Error (invalid parameters)
  console.log(err)
})
```

**Default environment is production.**

