### PR TITLE
change the CardBuilder Validate to false

### DIFF
--- a/android/src/main/java/com/pw/droplet/braintree/Braintree.java
+++ b/android/src/main/java/com/pw/droplet/braintree/Braintree.java
@@ -75,7 +75,7 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
       .expirationMonth(expirationMonth)
       .expirationYear(expirationYear)
       .cvv(cvv)
-      .validate(true);
+      .validate(false);
 
     Card.tokenize(this.mBraintreeFragment, cardBuilder);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-braintree-xplat",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Cross platform Braintree module",
   "main": "index",
   "author": {


### PR DESCRIPTION
resolves: https://github.com/kraffslol/react-native-braintree-xplat/issues/20
this bug was introduced by https://github.com/kraffslol/react-native-braintree-xplat/commit/d8757575e27e21dbfbba6f4363b738e279f911ec on Aug 10.

As a result, when you use an invalid card, the function call hangs and catch is never called.