### PR TITLE
Push modal onto presentedViewController

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -200,7 +200,9 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 }
 
 - (void)paymentDriver:(id)paymentDriver requestsDismissalOfViewController:(UIViewController *)viewController {
-    [self.reactRoot dismissViewControllerAnimated:YES completion:nil];
+    if (!viewController.isBeingDismissed) {
+        [viewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    }
 }
 
 #pragma mark - BTDropInViewControllerDelegate
@@ -213,12 +215,12 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 - (void)dropInViewController:(BTDropInViewController *)viewController didSucceedWithTokenization:(BTPaymentMethodNonce *)paymentMethodNonce {
 
     self.callback(@[[NSNull null],paymentMethodNonce.nonce]);
-    [viewController dismissViewControllerAnimated:YES completion:nil];
+    [self.reactRoot dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)dropInViewControllerDidCancel:(__unused BTDropInViewController *)viewController {
-    [viewController dismissViewControllerAnimated:YES completion:nil];
     self.callback(@[@"Drop-In ViewController Closed", [NSNull null]]);
+    [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (UIViewController*)reactRoot {

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -89,8 +89,7 @@ RCT_EXPORT_METHOD(showPaymentViewController:(NSDictionary *)options callback:(RC
 
             dropInViewController.paymentRequest = paymentRequest;
         }
-
-        self.reactRoot = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+        
         [self.reactRoot presentViewController:navigationController animated:YES completion:nil];
     });
 }
@@ -197,12 +196,10 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 #pragma mark - BTViewControllerPresentingDelegate
 
 - (void)paymentDriver:(id)paymentDriver requestsPresentationOfViewController:(UIViewController *)viewController {
-    self.reactRoot = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [self.reactRoot presentViewController:viewController animated:YES completion:nil];
 }
 
 - (void)paymentDriver:(id)paymentDriver requestsDismissalOfViewController:(UIViewController *)viewController {
-    self.reactRoot = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [self.reactRoot dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -222,6 +219,19 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 - (void)dropInViewControllerDidCancel:(__unused BTDropInViewController *)viewController {
     [viewController dismissViewControllerAnimated:YES completion:nil];
     self.callback(@[@"Drop-In ViewController Closed", [NSNull null]]);
+}
+
+- (UIViewController*)reactRoot {
+    UIViewController *root  = [UIApplication sharedApplication].keyWindow.rootViewController;
+    UIViewController *maybeModal = root.presentedViewController;
+    
+    UIViewController *modalRoot = root;
+    
+    if (maybeModal != nil) {
+        modalRoot = maybeModal;
+    }
+
+    return modalRoot;
 }
 
 @end


### PR DESCRIPTION
When trying to use this library on top of a modal it silently fails
because it's trying to present on top of the root view which already has
a modal on top of it.

This changes reactRoot to a getter which will return the correct
UIViewController to push onto, either the root or the currently
presented modal.

Thanks @gilesvangruisen for doing all the hard work! 😃 