### PR TITLE
Handle nil tokenizedPayPalAccount

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -103,12 +103,13 @@ RCT_EXPORT_METHOD(showPayPalViewController:(RCTResponseSenderBlock)callback)
         payPalDriver.viewControllerPresentingDelegate = self;
 
         [payPalDriver authorizeAccountWithCompletion:^(BTPayPalAccountNonce *tokenizedPayPalAccount, NSError *error) {
-            NSArray *args = @[];
-            if ( error == nil ) {
-                args = @[[NSNull null], tokenizedPayPalAccount.nonce, tokenizedPayPalAccount.email, tokenizedPayPalAccount.firstName, tokenizedPayPalAccount.lastName, tokenizedPayPalAccount.phone];
-            } else {
+            NSArray *args = @[[NSNull null]];
+            if ( error == nil && tokenizedPayPalAccount != nil ) {
+                args = @[[NSNull null], tokenizedPayPalAccount.nonce, tokenizedPayPalAccount.email, tokenizedPayPalAccount.firstName, tokenizedPayPalAccount.lastName, tokenizedPayPalAccount.phone];   
+            } else if ( error != nil ) {
                 args = @[error.description, [NSNull null]];
             }
+
             callback(args);
         }];
     });


### PR DESCRIPTION
When the user closes the paypal window via the `Done` button or `Cancel
Sandbox Purchase` both `error` and `tokenizedPayPalAccount` are nil
which throws an exception.

To handle this, we now explicitly check for truthiness of
`tokenizedPayPalAccount` before the success branch and check if `error`
is not nil before trying to return the error description.

By default we return nil in cases where there is no description.