### PR TITLE
Bug fix: BTClient.setup promise never resolves for first-time buyers using PayPal 

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -220,7 +220,8 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 }
 
 - (void)dropInViewController:(BTDropInViewController *)viewController didSucceedWithTokenization:(BTPaymentMethodNonce *)paymentMethodNonce {
-    if (runCallback) {
+    // when the user pays for the first time with paypal, dropInViewControllerWillComplete is never called, yet the callback should be invoked.  the second condition checks for that
+    if (runCallback || ([paymentMethodNonce.type isEqualToString:@"PayPal"] && [viewController.paymentMethodNonces count] == 1)) {
         runCallback = FALSE;
         self.callback(@[[NSNull null],paymentMethodNonce.nonce]);
     }


### PR DESCRIPTION
If someone purchases for the first time (no existing payment methods) and uses PayPal, the JS promise never resolves.  This is because dropInViewControllerWillComplete does not get invoked in that unique situation.  This fixes that.

This was uncovered by PR #32, which my esteemed colleague @TSMMark submitted a ways back.  Upon testing we discovered one unique condition that the PR didn't cover.

The following tests were run successfully:
1) No existing payment methods -> purchase with PayPal
2) No existing payment methods -> purchase with Credit Card
3) 1 existing PayPal account -> pay with that single account
4) 1 existing CC account -> pay with that single account
5) 1 existing PayPal account -> purchase with 2nd PayPal account
6) 1 existing PayPal account -> purchase with new CC account
7) 1 existing CC account -> purchase with 2nd CC account
8) 1 existing CC account -> purchase with new PayPal account

People are very likely to use PayPal for their first purchase, and this PR is critical to allowing that experience.  Thank you!
