### PR TITLE
Fix "Non-portable path" error in Xcode 8.3

### DIFF
--- a/ios/RCTBraintree/Braintree/BraintreeCore/BTAnalyticsMetadata.m
+++ b/ios/RCTBraintree/Braintree/BraintreeCore/BTAnalyticsMetadata.m
@@ -1,4 +1,4 @@
-#import "BTAnalyticsMetaData.h"
+#import "BTAnalyticsMetadata.h"
 
 #import "Braintree-Version.h"
 #import "BTKeychain.h"


### PR DESCRIPTION
Got this error in Xcode 8.3:

```
/node_modules/react-native-braintree-xplat/ios/RCTBraintree/Braintree/BraintreeCore/BTAnalyticsMetadata.m:1:9:
Non-portable path to file '"BTAnalyticsMetadata.h"'; specified path differs in case from file name on disk
```

This was fixed in `braintree_ios` in January: https://github.com/braintree/braintree_ios/commit/57ea40e56e6110397b757743f45160882eb1b748