### PR TITLE
Check if phone is nil before adding it to args

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -104,9 +104,13 @@ RCT_EXPORT_METHOD(showPayPalViewController:(RCTResponseSenderBlock)callback)
         payPalDriver.viewControllerPresentingDelegate = self;
 
         [payPalDriver authorizeAccountWithCompletion:^(BTPayPalAccountNonce *tokenizedPayPalAccount, NSError *error) {
-            NSArray *args = @[[NSNull null]];
+            NSMutableArray *args = @[[NSNull null]];
             if ( error == nil && tokenizedPayPalAccount != nil ) {
-                args = @[[NSNull null], tokenizedPayPalAccount.nonce, tokenizedPayPalAccount.email, tokenizedPayPalAccount.firstName, tokenizedPayPalAccount.lastName, tokenizedPayPalAccount.phone];   
+                args = [@[[NSNull null], tokenizedPayPalAccount.nonce, tokenizedPayPalAccount.email, tokenizedPayPalAccount.firstName, tokenizedPayPalAccount.lastName] mutableCopy];
+
+                if (tokenizedPayPalAccount.phone != nil) {
+                    [args addObject:tokenizedPayPalAccount.phone];
+                }
             } else if ( error != nil ) {
                 args = @[error.description, [NSNull null]];
             }


### PR DESCRIPTION
In our application `tokenizedPayPalAccount.phone` was nil and caused the application to crash.

This changes the `NSArray` into a `NSMutableArray` so we can conditionally push the phone number if it's not nil.