### PR TITLE
Card validation in iOS

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -129,6 +129,7 @@ RCT_EXPORT_METHOD(getCardNonce: (NSString *)cardNumber
 {
     BTCardClient *cardClient = [[BTCardClient alloc] initWithAPIClient: self.braintreeClient];
     BTCard *card = [[BTCard alloc] initWithNumber:cardNumber expirationMonth:expirationMonth expirationYear:expirationYear cvv:cvv];
+    card.shouldValidate = YES;
 
     [cardClient tokenizeCard:card
                   completion:^(BTCardNonce *tokenizedCard, NSError *error) {


### PR DESCRIPTION
A long time ago I had this pull request which accepted CVV code when creating credit card:
https://github.com/kraffslol/react-native-braintree-xplat/pull/6/files

However, validate method was called only on Android which created an inconsistency with iOS.
By default, shouldValidate should be set to YES in order to validate card number and CVV code.