### PR TITLE
Add support for title, description and amount options.

### DIFF
--- a/android/src/main/java/com/pw/droplet/braintree/Braintree.java
+++ b/android/src/main/java/com/pw/droplet/braintree/Braintree.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.ReadableMap;
 
 public class Braintree extends ReactContextBaseJavaModule implements ActivityEventListener {
   private static final int PAYMENT_REQUEST = 1706816330;
@@ -86,19 +87,38 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
   }
 
   @ReactMethod
-  public void paymentRequest(final String callToActionText, final Callback successCallback, final Callback errorCallback) {
+  public void paymentRequest(final ReadableMap options, final Callback successCallback, final Callback errorCallback) {
     this.successCallback = successCallback;
     this.errorCallback = errorCallback;
     PaymentRequest paymentRequest = null;
 
-    if (callToActionText != null) {
-      paymentRequest = new PaymentRequest()
-        .submitButtonText(callToActionText)
-        .clientToken(this.getToken());
-    } else {
-      paymentRequest = new PaymentRequest()
-        .clientToken(this.getToken());
+    String callToActionText = null;
+    String title = null;
+    String description = null;
+    String amount = null;
+
+    if (options.hasKey("callToActionText")) {
+      callToActionText = options.getString("callToActionText");
     }
+
+    if (options.hasKey("title")) {
+      title = options.getString("title");
+    }
+
+    if (options.hasKey("description")) {
+      description = options.getString("description");
+    }
+
+    if (options.hasKey("amount")) {
+      amount = options.getString("amount");
+    }
+
+    paymentRequest = new PaymentRequest()
+      .submitButtonText(callToActionText)
+      .primaryDescription(title)
+      .secondaryDescription(description)
+      .amount(amount)
+      .clientToken(this.getToken());
 
     (getCurrentActivity()).startActivityForResult(
       paymentRequest.getIntent(getCurrentActivity()),

--- a/index.android.js
+++ b/index.android.js
@@ -1,33 +1,47 @@
 'use strict';
 
-import { NativeModules, processColor } from 'react-native';
+import {NativeModules, processColor} from 'react-native';
 var Braintree = NativeModules.Braintree;
 
 module.exports = {
   setup(token) {
     return new Promise(function(resolve, reject) {
-      Braintree.setup(token, (test) => resolve(test), (err) => reject(err));
+      Braintree.setup(token, test => resolve(test), err => reject(err));
     });
   },
 
   getCardNonce(cardNumber, expirationMonth, expirationYear, cvv) {
     return new Promise(function(resolve, reject) {
-      Braintree.getCardNonce(cardNumber, expirationMonth, expirationYear, cvv, (nonce) => resolve(nonce), (err) => reject(err))
+      Braintree.getCardNonce(
+        cardNumber,
+        expirationMonth,
+        expirationYear,
+        cvv,
+        nonce => resolve(nonce),
+        err => reject(err)
+      );
     });
   },
 
   showPaymentViewController(config = {}) {
     var options = {
       callToActionText: config.callToActionText,
+      title: config.title,
+      description: config.description,
+      amount: config.amount,
     };
     return new Promise(function(resolve, reject) {
-      Braintree.paymentRequest(options.callToActionText, (nonce) => resolve(nonce), (error) => reject(error));
+      Braintree.paymentRequest(
+        options,
+        nonce => resolve(nonce),
+        error => reject(error)
+      );
     });
   },
 
   showPayPalViewController() {
     return new Promise(function(resolve, reject) {
-      Braintree.paypalRequest((nonce) => resolve(nonce), (error) => reject(error));
+      Braintree.paypalRequest(nonce => resolve(nonce), error => reject(error));
     });
   },
 };

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,65 +1,72 @@
 'use strict';
 
-import { NativeModules, processColor } from 'react-native';
+import {NativeModules, processColor} from 'react-native';
 var RCTBraintree = NativeModules.Braintree;
 
 var Braintree = {
+  setupWithURLScheme(token, urlscheme) {
+    return new Promise(function(resolve, reject) {
+      RCTBraintree.setupWithURLScheme(token, urlscheme, function(success) {
+        success == true ? resolve(true) : reject('Invalid Token');
+      });
+    });
+  },
 
-	setupWithURLScheme(token, urlscheme) {
-		return new Promise(function(resolve, reject) {
-			RCTBraintree.setupWithURLScheme(token, urlscheme, function(success) {
-				success == true ? resolve(true) : reject("Invalid Token");
-			});
-		});
-	},
+  setup(token) {
+    return new Promise(function(resolve, reject) {
+      RCTBraintree.setup(token, function(success) {
+        success == true ? resolve(true) : reject('Invalid Token');
+      });
+    });
+  },
 
-	setup(token) {
-		return new Promise(function(resolve, reject) {
-			RCTBraintree.setup(token, function(success) {
-				success == true ? resolve(true) : reject("Invalid Token");
-			});
-		});
-	},
-
-	showPaymentViewController(config = {}) {
+  showPaymentViewController(config = {}) {
     var options = {
       tintColor: processColor(config.tintColor),
       bgColor: processColor(config.bgColor),
       barBgColor: processColor(config.barBgColor),
       barTintColor: processColor(config.barTintColor),
       callToActionText: config.callToActionText,
+      title: config.title,
+      description: config.description,
+      amount: config.amount,
     };
-		return new Promise(function(resolve, reject) {
-			RCTBraintree.showPaymentViewController(options, function(err, nonce) {
-				nonce != null ? resolve(nonce) : reject(err);
-			});
-		});
-	},
-
-	showPayPalViewController() {
-		return new Promise(function(resolve, reject) {
-			RCTBraintree.showPayPalViewController(function(err, nonce) {
-				nonce != null ? resolve(nonce) : reject(err);
-			});
-		});
-	},
-
-  getCardNonce(cardNumber, expirationMonth, expirationYear, cvv) {
-  	return new Promise(function(resolve, reject) {
-  		RCTBraintree.getCardNonce(cardNumber, expirationMonth, expirationYear, cvv, function(err, nonce) {
-  			nonce != null ? resolve(nonce) : reject(err);
-  		});
-  	});
+    return new Promise(function(resolve, reject) {
+      RCTBraintree.showPaymentViewController(options, function(err, nonce) {
+        nonce != null ? resolve(nonce) : reject(err);
+      });
+    });
   },
 
-	getDeviceData(options = {}) {
-		return new Promise(function(resolve, reject) {
-			RCTBraintree.getDeviceData(options, function(err, deviceData) {
-				deviceData != null ? resolve(deviceData) : reject(err);
-			});
-		});
-	}
+  showPayPalViewController() {
+    return new Promise(function(resolve, reject) {
+      RCTBraintree.showPayPalViewController(function(err, nonce) {
+        nonce != null ? resolve(nonce) : reject(err);
+      });
+    });
+  },
 
+  getCardNonce(cardNumber, expirationMonth, expirationYear, cvv) {
+    return new Promise(function(resolve, reject) {
+      RCTBraintree.getCardNonce(
+        cardNumber,
+        expirationMonth,
+        expirationYear,
+        cvv,
+        function(err, nonce) {
+          nonce != null ? resolve(nonce) : reject(err);
+        }
+      );
+    });
+  },
+
+  getDeviceData(options = {}) {
+    return new Promise(function(resolve, reject) {
+      RCTBraintree.getDeviceData(options, function(err, deviceData) {
+        deviceData != null ? resolve(deviceData) : reject(err);
+      });
+    });
+  },
 };
 
 module.exports = Braintree;

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -73,8 +73,15 @@ RCT_EXPORT_METHOD(showPaymentViewController:(NSDictionary *)options callback:(RC
         UIColor *barBgColor = options[@"barBgColor"];
         UIColor *barTintColor = options[@"barTintColor"];
 
+        NSString *title = options[@"title"];
+        NSString *description = options[@"description"];
+        NSString *amount = options[@"amount"];
+
         if (tintColor) dropInViewController.view.tintColor = [RCTConvert UIColor:tintColor];
         if (bgColor) dropInViewController.view.backgroundColor = [RCTConvert UIColor:bgColor];
+        if (title) [dropInViewController.paymentRequest setTitle:title];
+        if (description) [dropInViewController.paymentRequest setDescription:description];
+        if (amount) [dropInViewController.paymentRequest setAmount:amount];
 
         dropInViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(userDidCancelPayment)];
 
@@ -91,7 +98,7 @@ RCT_EXPORT_METHOD(showPaymentViewController:(NSDictionary *)options callback:(RC
 
             dropInViewController.paymentRequest = paymentRequest;
         }
-        
+
         [self.reactRoot presentViewController:navigationController animated:YES completion:nil];
     });
 }
@@ -147,14 +154,14 @@ RCT_EXPORT_METHOD(getCardNonce: (NSString *)cardNumber
 RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        
+
         NSLog(@"%@", options);
-        
+
         NSError *error = nil;
         NSString *deviceData = nil;
         NSString *environment = options[@"environment"];
         NSString *dataSelector = options[@"dataCollector"];
-        
+
         //Initialize the data collector and specify environment
         if([environment isEqualToString: @"development"]){
             self.dataCollector = [[BTDataCollector alloc]
@@ -166,7 +173,7 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
             self.dataCollector = [[BTDataCollector alloc]
                                   initWithEnvironment:BTDataCollectorEnvironmentSandbox];
         }
-        
+
         //Data collection methods
         if ([dataSelector isEqualToString: @"card"]){
             deviceData = [self.dataCollector collectCardFraudData];
@@ -180,14 +187,14 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
             error = [NSError errorWithDomain:@"RCTBraintree" code:255 userInfo:details];
             NSLog (@"Invalid data collector. Use one of: card, paypal or both");
         }
-        
+
         NSArray *args = @[];
         if ( error == nil ) {
             args = @[[NSNull null], deviceData];
         } else {
             args = @[error.description, [NSNull null]];
         }
-        
+
         callback(args);
     });
 }
@@ -240,9 +247,9 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 - (UIViewController*)reactRoot {
     UIViewController *root  = [UIApplication sharedApplication].keyWindow.rootViewController;
     UIViewController *maybeModal = root.presentedViewController;
-    
+
     UIViewController *modalRoot = root;
-    
+
     if (maybeModal != nil) {
         modalRoot = maybeModal;
     }

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -79,9 +79,6 @@ RCT_EXPORT_METHOD(showPaymentViewController:(NSDictionary *)options callback:(RC
 
         if (tintColor) dropInViewController.view.tintColor = [RCTConvert UIColor:tintColor];
         if (bgColor) dropInViewController.view.backgroundColor = [RCTConvert UIColor:bgColor];
-        if (title) [dropInViewController.paymentRequest setTitle:title];
-        if (description) [dropInViewController.paymentRequest setDescription:description];
-        if (amount) [dropInViewController.paymentRequest setAmount:amount];
 
         dropInViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(userDidCancelPayment)];
 
@@ -98,6 +95,10 @@ RCT_EXPORT_METHOD(showPaymentViewController:(NSDictionary *)options callback:(RC
 
             dropInViewController.paymentRequest = paymentRequest;
         }
+
+        if (title) [dropInViewController.paymentRequest setSummaryTitle:title];
+        if (description) [dropInViewController.paymentRequest setSummaryDescription:description];
+        if (amount) [dropInViewController.paymentRequest setDisplayAmount:amount];
 
         [self.reactRoot presentViewController:navigationController animated:YES completion:nil];
     });


### PR DESCRIPTION
Usage:

```
const options = {
  title: 'item title',
  description: 'description of item',
  amount: '$99.95',
  callToActionText: 'Pay!',
};

BTClient.showPaymentViewController(options)
  .then((nonce) => {
    // payment succeeded, pass nonce to server
  })
  .catch((err) => {
    // error handling
  });
```

**Android**
https://developers.braintreepayments.com/guides/drop-in/android/v1
```
title       => primaryDescription
description => secondaryDescription
amount      => amount
```

<img width="421" alt="screen shot 2017-05-25 at 8 59 17 pm" src="https://cloud.githubusercontent.com/assets/542/26476478/206309a2-418d-11e7-9277-72f21a20266b.png">

**iOS**
https://developers.braintreepayments.com/guides/drop-in/ios/v3

```
summaryTitle       => title
summaryDescription => description
displayAmount      => amount
```

<img width="375" alt="screen shot 2017-05-25 at 8 58 53 pm" src="https://cloud.githubusercontent.com/assets/542/26476479/206388fa-418d-11e7-8bc9-3fd041a75959.png">
