### PR TITLE
Bug fixed - import correct header to support rn0.40 or above

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.h
+++ b/ios/RCTBraintree/RCTBraintree.h
@@ -7,6 +7,9 @@
 //
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTUtils.h>
+#import <React/RCTConvert.h>
+
 #import "BraintreeCore.h"
 #import "BraintreePayPal.h"
 #import "BraintreeCard.h"

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -7,8 +7,6 @@
 //
 
 #import "RCTBraintree.h"
-#import "RCTUtils.h"
-#import "RCTConvert.h"
 
 @implementation RCTBraintree {
     bool runCallback;


### PR DESCRIPTION
I found some header file were imported into .m files, which is not a proper way to go. And, the header should be changed to `<React/.....h>`, so that it can be compiled on `react-native >= 0.40`