### PR TITLE
Invoke callback when user cancels payment

### DIFF
--- a/android/src/main/java/com/pw/droplet/braintree/Braintree.java
+++ b/android/src/main/java/com/pw/droplet/braintree/Braintree.java
@@ -206,6 +206,9 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
             data.getSerializableExtra(BraintreePaymentActivity.EXTRA_ERROR_MESSAGE)
           );
           break;
+        case Activity.RESULT_CANCELED:
+          this.errorCallback.invoke("RESULT_CANCELED");
+          break;
         default:
           break;
       }


### PR DESCRIPTION
Implements the solution suggested at https://github.com/kraffslol/react-native-braintree-xplat/issues/34
Triggered when pressing the hardware "back" button.