### PR TITLE
Single "map" argument for `getCardNonce`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,40 @@ BTClient.showPayPalViewController().then(function(nonce) {
 
 ## Custom Integration
 If you only want to tokenize credit card information, you can use the following:
+
 ```js
-BTClient.getCardNonce("4111111111111111", "10", "20", "400").then(function(nonce) {
+const card = {
+  number: "4111111111111111",
+  expirationDate: "10/20", // or "10/2020" or any valid date
+  cvv: "400",
+}
+
+BTClient.getCardNonce(card).then(function(nonce) {
   //payment succeeded, pass nonce to server
 })
 .catch(function(err) {
   //error handling
 });
+
+// Full list of card parameters:
+type Card = {
+  number: string,
+  cvv: string,
+  expirationDate: string,
+  cardholderName: string,
+  firstName: string,
+  lastName: string,
+  company: string,
+  countryName: string,
+  countryCodeAlpha2: string,
+  countryCodeAlpha3: string,
+  countryCodeNumeric: string,
+  locality: string,
+  postalCode: string,
+  region: string,
+  streetAddress: string,
+  extendedAddress: string,
+}
 ```
 
 ## One Touch on iOS
@@ -232,14 +259,14 @@ If your app is built using iOS 9 as its Base SDK, then you must add URLs to a wh
   BTClient.setupWithURLScheme(token, 'your.bundle.id.payments');
   ```
   #### For xplat, you can do something like this:
-  
+
   ```js
-  
+
    if (Platform.OS === 'ios') {
         BTClient.setupWithURLScheme(token, 'your.bundle.id.payments');
     } else {
         BTClient.setup(token);
-    }  
+    }
   ```
 
 3. Add this delegate method (callback) to your AppDelegate.m

--- a/android/src/main/java/com/pw/droplet/braintree/Braintree.java
+++ b/android/src/main/java/com/pw/droplet/braintree/Braintree.java
@@ -88,6 +88,7 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
               BraintreeError cvvError = cardErrors.errorFor("cvv");
               BraintreeError expirationDateError = cardErrors.errorFor("expirationDate");
               BraintreeError expirationYearError = cardErrors.errorFor("expirationYear");
+              BraintreeError postalCode = cardErrors.errorFor("postalCode");
 
               if (numberError != null) {
                 errors.put("card_number", numberError.getMessage());
@@ -105,6 +106,11 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
                 errors.put("expiration_year", expirationYearError.getMessage());
               }
 
+              // TODO add more fields
+              if (postalCode != null) {
+                errors.put("postal_code", postalCode.getMessage());
+              }
+
               nonceErrorCallback(gson.toJson(errors));
             } else {
               nonceErrorCallback(errorWithResponse.getErrorResponse());
@@ -120,16 +126,66 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
   }
 
   @ReactMethod
-  public void getCardNonce(final String cardNumber, final String expirationMonth, final String expirationYear, final String cvv, final Callback successCallback, final Callback errorCallback) {
+  public void getCardNonce(final ReadableMap parameters, final Callback successCallback, final Callback errorCallback) {
     this.successCallback = successCallback;
     this.errorCallback = errorCallback;
 
     CardBuilder cardBuilder = new CardBuilder()
-      .cardNumber(cardNumber)
-      .expirationMonth(expirationMonth)
-      .expirationYear(expirationYear)
-      .cvv(cvv)
       .validate(true);
+
+      if (parameters.hasKey("number"))
+        cardBuilder.cardNumber(parameters.getString("number"));
+
+      if (parameters.hasKey("cvv"))
+        cardBuilder.cvv(parameters.getString("cvv"));
+
+      if (parameters.hasKey("expirationMonth"))
+        cardBuilder.expirationMonth(parameters.getString("expirationMonth"));
+
+      if (parameters.hasKey("expirationYear"))
+        cardBuilder.expirationYear(parameters.getString("expirationYear"));
+
+      if (parameters.hasKey("expirationDate"))
+        cardBuilder.expirationDate(parameters.getString("expirationDate"));
+
+      if (parameters.hasKey("cardholderName"))
+        cardBuilder.cardholderName(parameters.getString("cardholderName"));
+
+      if (parameters.hasKey("firstName"))
+        cardBuilder.firstName(parameters.getString("firstName"));
+
+      if (parameters.hasKey("lastName"))
+        cardBuilder.lastName(parameters.getString("lastName"));
+
+      if (parameters.hasKey("company"))
+        cardBuilder.company(parameters.getString("company"));
+
+      if (parameters.hasKey("countryName"))
+        cardBuilder.countryName(parameters.getString("countryName"));
+
+      if (parameters.hasKey("countryCodeAlpha2"))
+        cardBuilder.countryCodeAlpha2(parameters.getString("countryCodeAlpha2"));
+
+      if (parameters.hasKey("countryCodeAlpha3"))
+        cardBuilder.countryCodeAlpha3(parameters.getString("countryCodeAlpha3"));
+
+      if (parameters.hasKey("countryCodeNumeric"))
+        cardBuilder.countryCodeNumeric(parameters.getString("countryCodeNumeric"));
+
+      if (parameters.hasKey("locality"))
+        cardBuilder.locality(parameters.getString("locality"));
+
+      if (parameters.hasKey("postalCode"))
+        cardBuilder.postalCode(parameters.getString("postalCode"));
+
+      if (parameters.hasKey("region"))
+        cardBuilder.region(parameters.getString("region"));
+
+      if (parameters.hasKey("streetAddress"))
+        cardBuilder.streetAddress(parameters.getString("streetAddress"));
+
+      if (parameters.hasKey("extendedAddress"))
+        cardBuilder.extendedAddress(parameters.getString("extendedAddress"));
 
     Card.tokenize(this.mBraintreeFragment, cardBuilder);
   }

--- a/android/src/main/java/com/pw/droplet/braintree/Braintree.java
+++ b/android/src/main/java/com/pw/droplet/braintree/Braintree.java
@@ -87,7 +87,6 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
               BraintreeError numberError = cardErrors.errorFor("number");
               BraintreeError cvvError = cardErrors.errorFor("cvv");
               BraintreeError expirationDateError = cardErrors.errorFor("expirationDate");
-              BraintreeError expirationYearError = cardErrors.errorFor("expirationYear");
               BraintreeError postalCode = cardErrors.errorFor("postalCode");
 
               if (numberError != null) {
@@ -100,10 +99,6 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
 
               if (expirationDateError != null) {
                 errors.put("expiration_date", expirationDateError.getMessage());
-              }
-
-              if (expirationYearError != null) {
-                errors.put("expiration_year", expirationYearError.getMessage());
               }
 
               // TODO add more fields
@@ -139,12 +134,8 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
     if (parameters.hasKey("cvv"))
       cardBuilder.cvv(parameters.getString("cvv"));
 
-    if (parameters.hasKey("expirationMonth"))
-      cardBuilder.expirationMonth(parameters.getString("expirationMonth"));
-
-    if (parameters.hasKey("expirationYear"))
-      cardBuilder.expirationYear(parameters.getString("expirationYear"));
-
+    // In order to keep compatibility with iOS implementation, do not accept expirationMonth and exporationYear,
+    // accept rather expirationDate (which is combination of expirationMonth/expirationYear)
     if (parameters.hasKey("expirationDate"))
       cardBuilder.expirationDate(parameters.getString("expirationDate"));
 

--- a/android/src/main/java/com/pw/droplet/braintree/Braintree.java
+++ b/android/src/main/java/com/pw/droplet/braintree/Braintree.java
@@ -133,59 +133,59 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
     CardBuilder cardBuilder = new CardBuilder()
       .validate(true);
 
-      if (parameters.hasKey("number"))
-        cardBuilder.cardNumber(parameters.getString("number"));
+    if (parameters.hasKey("number"))
+      cardBuilder.cardNumber(parameters.getString("number"));
 
-      if (parameters.hasKey("cvv"))
-        cardBuilder.cvv(parameters.getString("cvv"));
+    if (parameters.hasKey("cvv"))
+      cardBuilder.cvv(parameters.getString("cvv"));
 
-      if (parameters.hasKey("expirationMonth"))
-        cardBuilder.expirationMonth(parameters.getString("expirationMonth"));
+    if (parameters.hasKey("expirationMonth"))
+      cardBuilder.expirationMonth(parameters.getString("expirationMonth"));
 
-      if (parameters.hasKey("expirationYear"))
-        cardBuilder.expirationYear(parameters.getString("expirationYear"));
+    if (parameters.hasKey("expirationYear"))
+      cardBuilder.expirationYear(parameters.getString("expirationYear"));
 
-      if (parameters.hasKey("expirationDate"))
-        cardBuilder.expirationDate(parameters.getString("expirationDate"));
+    if (parameters.hasKey("expirationDate"))
+      cardBuilder.expirationDate(parameters.getString("expirationDate"));
 
-      if (parameters.hasKey("cardholderName"))
-        cardBuilder.cardholderName(parameters.getString("cardholderName"));
+    if (parameters.hasKey("cardholderName"))
+      cardBuilder.cardholderName(parameters.getString("cardholderName"));
 
-      if (parameters.hasKey("firstName"))
-        cardBuilder.firstName(parameters.getString("firstName"));
+    if (parameters.hasKey("firstName"))
+      cardBuilder.firstName(parameters.getString("firstName"));
 
-      if (parameters.hasKey("lastName"))
-        cardBuilder.lastName(parameters.getString("lastName"));
+    if (parameters.hasKey("lastName"))
+      cardBuilder.lastName(parameters.getString("lastName"));
 
-      if (parameters.hasKey("company"))
-        cardBuilder.company(parameters.getString("company"));
+    if (parameters.hasKey("company"))
+      cardBuilder.company(parameters.getString("company"));
 
-      if (parameters.hasKey("countryName"))
-        cardBuilder.countryName(parameters.getString("countryName"));
+    if (parameters.hasKey("countryName"))
+      cardBuilder.countryName(parameters.getString("countryName"));
 
-      if (parameters.hasKey("countryCodeAlpha2"))
-        cardBuilder.countryCodeAlpha2(parameters.getString("countryCodeAlpha2"));
+    if (parameters.hasKey("countryCodeAlpha2"))
+      cardBuilder.countryCodeAlpha2(parameters.getString("countryCodeAlpha2"));
 
-      if (parameters.hasKey("countryCodeAlpha3"))
-        cardBuilder.countryCodeAlpha3(parameters.getString("countryCodeAlpha3"));
+    if (parameters.hasKey("countryCodeAlpha3"))
+      cardBuilder.countryCodeAlpha3(parameters.getString("countryCodeAlpha3"));
 
-      if (parameters.hasKey("countryCodeNumeric"))
-        cardBuilder.countryCodeNumeric(parameters.getString("countryCodeNumeric"));
+    if (parameters.hasKey("countryCodeNumeric"))
+      cardBuilder.countryCodeNumeric(parameters.getString("countryCodeNumeric"));
 
-      if (parameters.hasKey("locality"))
-        cardBuilder.locality(parameters.getString("locality"));
+    if (parameters.hasKey("locality"))
+      cardBuilder.locality(parameters.getString("locality"));
 
-      if (parameters.hasKey("postalCode"))
-        cardBuilder.postalCode(parameters.getString("postalCode"));
+    if (parameters.hasKey("postalCode"))
+      cardBuilder.postalCode(parameters.getString("postalCode"));
 
-      if (parameters.hasKey("region"))
-        cardBuilder.region(parameters.getString("region"));
+    if (parameters.hasKey("region"))
+      cardBuilder.region(parameters.getString("region"));
 
-      if (parameters.hasKey("streetAddress"))
-        cardBuilder.streetAddress(parameters.getString("streetAddress"));
+    if (parameters.hasKey("streetAddress"))
+      cardBuilder.streetAddress(parameters.getString("streetAddress"));
 
-      if (parameters.hasKey("extendedAddress"))
-        cardBuilder.extendedAddress(parameters.getString("extendedAddress"));
+    if (parameters.hasKey("extendedAddress"))
+      cardBuilder.extendedAddress(parameters.getString("extendedAddress"));
 
     Card.tokenize(this.mBraintreeFragment, cardBuilder);
   }

--- a/index.android.js
+++ b/index.android.js
@@ -1,7 +1,9 @@
 'use strict';
 
-import {NativeModules, processColor} from 'react-native';
-var Braintree = NativeModules.Braintree;
+import { NativeModules } from 'react-native';
+import { mapParameters } from './utils';
+
+const Braintree = NativeModules.Braintree;
 
 module.exports = {
   setup(token) {
@@ -10,13 +12,10 @@ module.exports = {
     });
   },
 
-  getCardNonce(cardNumber, expirationMonth, expirationYear, cvv) {
+  getCardNonce(parameters = {}) {
     return new Promise(function(resolve, reject) {
       Braintree.getCardNonce(
-        cardNumber,
-        expirationMonth,
-        expirationYear,
-        cvv,
+        mapParameters(parameters),
         nonce => resolve(nonce),
         err => reject(err)
       );

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,6 +1,12 @@
+// @flow
+
 'use strict';
 
 import { NativeModules, processColor } from 'react-native';
+import { mapParameters } from './utils';
+
+import type { CardParameters } from './types';
+
 const RCTBraintree = NativeModules.Braintree;
 
 var Braintree = {
@@ -46,9 +52,12 @@ var Braintree = {
     });
   },
 
-  getCardNonce(parameters = {}) {
+  getCardNonce(parameters: CardParameters = {}) {
     return new Promise(function(resolve, reject) {
-      RCTBraintree.getCardNonce(parameters, function(err, nonce) {
+      RCTBraintree.getCardNonce(mapParameters(parameters), function(
+        err,
+        nonce
+      ) {
         let jsonErr = null;
 
         try {

--- a/index.ios.js
+++ b/index.ios.js
@@ -57,7 +57,7 @@ var Braintree = {
           //
         }
 
-        nonce != null
+        nonce !== null
           ? resolve(nonce)
           : reject(
               jsonErr

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import {NativeModules, processColor} from 'react-native';
-var RCTBraintree = NativeModules.Braintree;
+import { NativeModules, processColor } from 'react-native';
+const RCTBraintree = NativeModules.Braintree;
 
 var Braintree = {
   setupWithURLScheme(token, urlscheme) {
@@ -46,17 +46,26 @@ var Braintree = {
     });
   },
 
-  getCardNonce(cardNumber, expirationMonth, expirationYear, cvv) {
+  getCardNonce(parameters = {}) {
     return new Promise(function(resolve, reject) {
-      RCTBraintree.getCardNonce(
-        cardNumber,
-        expirationMonth,
-        expirationYear,
-        cvv,
-        function(err, nonce) {
-          nonce != null ? resolve(nonce) : reject(err);
+      RCTBraintree.getCardNonce(parameters, function(err, nonce) {
+        let jsonErr = null;
+
+        try {
+          jsonErr = JSON.parse(err);
+        } catch (e) {
+          //
         }
-      );
+
+        nonce != null
+          ? resolve(nonce)
+          : reject(
+              jsonErr
+                ? jsonErr['BTCustomerInputBraintreeValidationErrorsKey'] ||
+                  jsonErr
+                : err
+            );
+      });
     });
   },
 

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -7,7 +7,6 @@
 //
 
 #import "RCTBraintree.h"
-#import "RCTConvert.h"
 
 @implementation RCTBraintree {
     bool runCallback;

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -7,6 +7,7 @@
 //
 
 #import "RCTBraintree.h"
+#import "RCTConvert.h"
 
 @implementation RCTBraintree {
     bool runCallback;
@@ -126,29 +127,34 @@ RCT_EXPORT_METHOD(showPayPalViewController:(RCTResponseSenderBlock)callback)
     });
 }
 
-RCT_EXPORT_METHOD(getCardNonce: (NSString *)cardNumber
-                  expirationMonth: (NSString *)expirationMonth
-                  expirationYear: (NSString *)expirationYear
-                  cvv: (NSString *)cvv
-                  callback: (RCTResponseSenderBlock)callback
-                  )
+RCT_EXPORT_METHOD(getCardNonce: (NSDictionary *)parameters callback: (RCTResponseSenderBlock)callback)
 {
     BTCardClient *cardClient = [[BTCardClient alloc] initWithAPIClient: self.braintreeClient];
-    BTCard *card = [[BTCard alloc] initWithNumber:cardNumber expirationMonth:expirationMonth expirationYear:expirationYear cvv:cvv];
+    BTCard *card = [[BTCard alloc] initWithParameters:parameters];
     card.shouldValidate = YES;
 
     [cardClient tokenizeCard:card
                   completion:^(BTCardNonce *tokenizedCard, NSError *error) {
-
                       NSArray *args = @[];
+
                       if ( error == nil ) {
                           args = @[[NSNull null], tokenizedCard.nonce];
                       } else {
-                          args = @[error.description, [NSNull null]];
+                          NSError *serialisationErr;
+                          NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[error userInfo]
+                                                                             options:NSJSONWritingPrettyPrinted
+                                                                               error:&serialisationErr];
+
+                          if (! jsonData) {
+                              args = @[serialisationErr.description, [NSNull null]];
+                          } else {
+                              NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+                              args = @[jsonString, [NSNull null]];
+                          }
                       }
+
                       callback(args);
-                  }
-     ];
+                  }];
 }
 
 RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)

--- a/types.js
+++ b/types.js
@@ -1,0 +1,47 @@
+// @flow
+
+export type CardParameters = {
+    number: string,
+    expirationMonth: string,
+    expirationYear: string,
+    cvv: string,
+    expirationDate: string,
+    cardholderName: string,
+    billingAddress: string,
+    firstName: string,
+    lastName: string,
+    company: string,
+    countryName: string,
+    countryCodeAlpha2: string,
+    countryCodeAlpha3: string,
+    countryCodeNumeric: string,
+    locality: string,
+    postalCode: string,
+    region: string,
+    streetAddress: string,
+    extendedAddress: string,
+  };
+
+  export type IOSCardParameters = {
+    number: string,
+    expirationMonth: string,
+    expirationYear: string,
+    cardholderName: string,
+    billingAddress: {
+      postalCode: string,
+      streetAddress: string,
+      extendedAddress: string,
+      locality: string,
+      region: string,
+      countryName: string,
+      countryCodeAlpha2: string,
+      countryCodeAlpha3: string,
+      countryCodeNumeric: string,
+      firstName: string,
+      lastName: string,
+      company: string,
+    },
+  };
+  };
+
+  export type AndroidCardParameters = CardParameters;

--- a/types.js
+++ b/types.js
@@ -1,47 +1,43 @@
 // @flow
 
 export type CardParameters = {
-    number: string,
-    expirationMonth: string,
-    expirationYear: string,
-    cvv: string,
-    expirationDate: string,
-    cardholderName: string,
-    billingAddress: string,
-    firstName: string,
-    lastName: string,
-    company: string,
+  number: string,
+  cvv: string,
+  expirationDate: string,
+  cardholderName: string,
+  firstName: string,
+  lastName: string,
+  company: string,
+  countryName: string,
+  countryCodeAlpha2: string,
+  countryCodeAlpha3: string,
+  countryCodeNumeric: string,
+  locality: string,
+  postalCode: string,
+  region: string,
+  streetAddress: string,
+  extendedAddress: string,
+};
+
+export type IOSCardParameters = {
+  number: string,
+  cvv: string,
+  expirationDate: string,
+  cardholderName: string,
+  billingAddress: {
+    postalCode: string,
+    streetAddress: string,
+    extendedAddress: string,
+    locality: string,
+    region: string,
     countryName: string,
     countryCodeAlpha2: string,
     countryCodeAlpha3: string,
     countryCodeNumeric: string,
-    locality: string,
-    postalCode: string,
-    region: string,
-    streetAddress: string,
-    extendedAddress: string,
-  };
+    firstName: string,
+    lastName: string,
+    company: string,
+  },
+};
 
-  export type IOSCardParameters = {
-    number: string,
-    expirationMonth: string,
-    expirationYear: string,
-    cardholderName: string,
-    billingAddress: {
-      postalCode: string,
-      streetAddress: string,
-      extendedAddress: string,
-      locality: string,
-      region: string,
-      countryName: string,
-      countryCodeAlpha2: string,
-      countryCodeAlpha3: string,
-      countryCodeNumeric: string,
-      firstName: string,
-      lastName: string,
-      company: string,
-    },
-  };
-  };
-
-  export type AndroidCardParameters = CardParameters;
+export type AndroidCardParameters = CardParameters;

--- a/utils.js
+++ b/utils.js
@@ -20,8 +20,6 @@ export function mapParameters(
   return {
     number: parameters.number,
     cvv: parameters.cvv,
-    // expirationMonth: parameters.expirationMonth,
-    // expirationYear: parameters.expirationYear,
     expirationDate: parameters.expirationDate,
     cardholderName: parameters.cardholderName,
     billingAddress: {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,42 @@
+// @flow
+
+import { Platform } from 'react-native';
+
+import type {
+  CardParameters,
+  AndroidCardParameters,
+  IOSCardParameters,
+} from './types';
+
+export function mapParameters(
+  parameters: CardParameters
+): AndroidCardParameters | IOSCardParameters {
+  if (Platform.OS === 'android') {
+    return parameters;
+  }
+
+  // iOS field mapping
+  // https://github.com/braintree/braintree_ios/blob/master/BraintreeCard/BTCard.m#L14
+  return {
+    number: parameters.number,
+    cvv: parameters.cvv,
+    // expirationMonth: parameters.expirationMonth,
+    // expirationYear: parameters.expirationYear,
+    expirationDate: parameters.expirationDate,
+    cardholderName: parameters.cardholderName,
+    billingAddress: {
+      postalCode: parameters.postalCode,
+      streetAddress: parameters.streetAddress,
+      extendedAddress: parameters.extendedAddress,
+      locality: parameters.locality,
+      region: parameters.region,
+      countryName: parameters.countryName,
+      countryCodeAlpha2: parameters.countryCodeAlpha2,
+      countryCodeAlpha3: parameters.countryCodeAlpha3,
+      countryCodeNumeric: parameters.countryCodeNumeric,
+      firstName: parameters.firstName,
+      lastName: parameters.lastName,
+      company: parameters.company,
+    },
+  };
+}


### PR DESCRIPTION
`getCardNonce` accepts single map argument instead of several arguments.

This change let's us validate additional fields, if enabled on Braintree backend - e.g. address, ZIP, cardholder name, ...