### PR TITLE
[iOS] Improved compatibility with RNN

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -284,16 +284,12 @@ RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options callback:(RCTResponseSen
 }
 
 - (UIViewController*)reactRoot {
-    UIViewController *root  = [UIApplication sharedApplication].keyWindow.rootViewController;
-    UIViewController *maybeModal = root.presentedViewController;
-
-    UIViewController *modalRoot = root;
-
-    if (maybeModal != nil) {
-        modalRoot = maybeModal;
+    UIViewController *root = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (root.presentedViewController) {
+        root = root.presentedViewController;
     }
 
-    return modalRoot;
+    return root;
 }
 
 @end


### PR DESCRIPTION
This change makes sure that the Braintree view controller will still be displayed when multiple levels deep into the view hierarchy, which is often the case when using React Native Navigation by Wix. 