### PR TITLE
Fix iOS crashing in getCardNonce on error case

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -144,8 +144,13 @@ RCT_EXPORT_METHOD(getCardNonce: (NSDictionary *)parameters callback: (RCTRespons
                       if ( error == nil ) {
                           args = @[[NSNull null], tokenizedCard.nonce];
                       } else {
+                          NSMutableDictionary *userInfo = [error.userInfo mutableCopy];
+                          
+                          [userInfo removeObjectForKey:@"com.braintreepayments.BTHTTPJSONResponseBodyKey"];
+                          [userInfo removeObjectForKey:@"com.braintreepayments.BTHTTPURLResponseKey"];
+                          
                           NSError *serialisationErr;
-                          NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[error userInfo]
+                          NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfo
                                                                              options:NSJSONWritingPrettyPrinted
                                                                                error:&serialisationErr];
 


### PR DESCRIPTION
Remove JSON incompatible objects from error object which is passed back to JS, fixes #91