### PR TITLE
Added react-native-braintree-xplat.podspec

### DIFF
--- a/react-native-braintree-xplat.podspec
+++ b/react-native-braintree-xplat.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-braintree-xplat"
+  s.version      = package['version']
+  s.summary      = "React Native Date Picker component for Android and iOS"
+
+  s.authors      = { "henninghall" => "henning.hall@hotmail.com" }
+  s.homepage     = "https://github.com/kraffslol/react-native-braintree-xplat"
+  s.license      = package['license']
+  s.platform     = :ios, "8.0"
+
+  s.source       = { :git => "https://github.com/kraffslol/react-native-braintree-xplat.git" }
+  s.source_files  = "ios/RCTBraintree/RCTBraintree.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
I added a very basic podspec to allow this project to be included with CocoaPods.
I'm very unfamiliar to the iOS stack ( react native dev ), but it was the only way for the to use this with expo-kit native project